### PR TITLE
Build simplified directory demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,48 +1,19 @@
-# Wordpress - ignore core, configuration, examples, uploads and logs.
-# https://github.com/github/gitignore/blob/main/WordPress.gitignore
+# Python artifacts
+__pycache__/
+*.py[cod]
+*$py.class
 
-# Core
-#
-# Note: if you want to stage/commit WP core files
-# you can delete this whole section/until Configuration.
-/wp-admin/
-/wp-content/index.php
-/wp-content/languages
-/wp-content/plugins/index.php
-/wp-content/themes/index.php
-/wp-includes/
-/index.php
-/license.txt
-/readme.html
-/wp-*.php
-/xmlrpc.php
+# Virtual environments
+.venv/
+venv/
+ENV/
 
-# Configuration
-wp-config.php
+# SQLite database
+*.db
+*.sqlite3
 
-# Example themes
-/wp-content/themes/twenty*/
+# Node modules (if experimenting with JS tooling)
+node_modules/
 
-# Example plugin
-/wp-content/plugins/hello.php
-
-# Uploads
-/wp-content/uploads/
-
-# Log files
-*.log
-
-# htaccess
-/.htaccess
-
-# All plugins
-#
-# Note: If you wish to whitelist plugins,
-# uncomment the next line
-#/wp-content/plugins
-
-# All themes
-#
-# Note: If you wish to whitelist themes,
-# uncomment the next line
-#/wp-content/themes
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# cit-hackathon-2025
+# Simple Community Directory
+
+This repository contains a lightweight demo web application that showcases a
+minimal people directory. The database keeps only the essential fields the team
+requested: **first name**, **last name**, and **ZIP code**.
+
+## Tech stack
+
+- **Python standard library** HTTP server for the API and static hosting
+- **SQLite** for persistent storage (created automatically on first run)
+- **Vanilla JavaScript** + HTML/CSS for the interface
+
+## Getting started
+
+1. Make sure you have Python 3.9 or newer installed.
+2. Run the development server:
+
+   ```bash
+   python app.py
+   ```
+
+3. Open <http://127.0.0.1:5000/> in your browser.
+
+## API
+
+| Method | Endpoint      | Description         |
+| ------ | ------------- | ------------------- |
+| GET    | `/api/people` | List all directory entries |
+| POST   | `/api/people` | Add a new entry (JSON body with `first_name`, `last_name`, `zip_code`) |
+
+## Notes
+
+- The SQLite database file (`people.db`) is ignored by Git and created
+  automatically with a few sample entries the first time the server starts.
+- The interface intentionally focuses on the simplest possible dataset while
+  still demonstrating a complete request/response cycle.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler
+from pathlib import Path
+from socketserver import TCPServer
+from typing import Dict, List
+
+APP_ROOT = Path(__file__).resolve().parent
+STATIC_DIR = APP_ROOT / "static"
+DB_PATH = APP_ROOT / "people.db"
+HOST = "0.0.0.0"
+PORT = 5000
+
+
+def get_connection() -> sqlite3.Connection:
+    connection = sqlite3.connect(DB_PATH)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def init_db() -> None:
+    with get_connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS people (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                first_name TEXT NOT NULL,
+                last_name TEXT NOT NULL,
+                zip_code TEXT NOT NULL
+            )
+            """
+        )
+        if conn.execute("SELECT COUNT(*) FROM people").fetchone()[0] == 0:
+            conn.executemany(
+                "INSERT INTO people (first_name, last_name, zip_code) VALUES (?, ?, ?)",
+                [
+                    ("Ada", "Lovelace", "20500"),
+                    ("Alan", "Turing", "02142"),
+                    ("Grace", "Hopper", "10001"),
+                ],
+            )
+            conn.commit()
+
+
+def list_people() -> List[Dict[str, str]]:
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "SELECT id, first_name, last_name, zip_code FROM people ORDER BY id"
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def create_person(payload: Dict[str, str]) -> Dict[str, str]:
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "INSERT INTO people (first_name, last_name, zip_code) VALUES (?, ?, ?)",
+            (
+                payload["first_name"].strip(),
+                payload["last_name"].strip(),
+                payload["zip_code"].strip(),
+            ),
+        )
+        conn.commit()
+        return {
+            "id": cursor.lastrowid,
+            "first_name": payload["first_name"].strip(),
+            "last_name": payload["last_name"].strip(),
+            "zip_code": payload["zip_code"].strip(),
+        }
+
+
+class DirectoryRequestHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(STATIC_DIR), **kwargs)
+
+    def log_message(self, format: str, *args) -> None:  # pragma: no cover
+        # Quieter output while running in the demo environment.
+        return
+
+    def _set_json_headers(self, status: HTTPStatus) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802 (keep http.server naming)
+        if self.path == "/api/people":
+            people = list_people()
+            payload = json.dumps({"people": people}).encode("utf-8")
+            self._set_json_headers(HTTPStatus.OK)
+            self.wfile.write(payload)
+            return
+
+        if self.path == "/":
+            self.path = "/index.html"
+
+        super().do_GET()
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/api/people":
+            self.send_error(HTTPStatus.NOT_FOUND, "Endpoint not found")
+            return
+
+        content_length = int(self.headers.get("Content-Length", "0"))
+        raw_body = self.rfile.read(content_length)
+
+        try:
+            payload = json.loads(raw_body.decode("utf-8"))
+        except json.JSONDecodeError:
+            self._set_json_headers(HTTPStatus.BAD_REQUEST)
+            self.wfile.write(
+                json.dumps({"error": "Invalid JSON payload"}).encode("utf-8")
+            )
+            return
+
+        required_fields = ["first_name", "last_name", "zip_code"]
+        missing = [field for field in required_fields if not payload.get(field)]
+        if missing:
+            self._set_json_headers(HTTPStatus.BAD_REQUEST)
+            self.wfile.write(
+                json.dumps(
+                    {
+                        "error": "Missing required fields",
+                        "details": missing,
+                    }
+                ).encode("utf-8")
+            )
+            return
+
+        person = create_person(payload)
+        self._set_json_headers(HTTPStatus.CREATED)
+        self.wfile.write(json.dumps(person).encode("utf-8"))
+
+
+def run_server() -> None:
+    init_db()
+    with TCPServer((HOST, PORT), DirectoryRequestHandler) as httpd:
+        print(f"Serving on http://{HOST}:{PORT}")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:  # pragma: no cover
+            print("\nShutting down...")
+
+
+if __name__ == "__main__":
+    run_server()

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,77 @@
+const listContainer = document.getElementById("people-body");
+const form = document.getElementById("person-form");
+const errorMessage = form.querySelector(".error");
+
+async function fetchPeople() {
+  const response = await fetch("/api/people");
+  if (!response.ok) {
+    throw new Error("Unable to load people");
+  }
+  const data = await response.json();
+  return data.people;
+}
+
+function renderRows(people) {
+  listContainer.innerHTML = "";
+  if (people.length === 0) {
+    const emptyRow = document.createElement("tr");
+    const emptyCell = document.createElement("td");
+    emptyCell.colSpan = 3;
+    emptyCell.textContent = "No entries yet.";
+    emptyCell.classList.add("empty");
+    emptyRow.appendChild(emptyCell);
+    listContainer.appendChild(emptyRow);
+    return;
+  }
+
+  for (const person of people) {
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td>${person.first_name}</td>
+      <td>${person.last_name}</td>
+      <td>${person.zip_code}</td>
+    `;
+    listContainer.appendChild(row);
+  }
+}
+
+async function refreshList() {
+  try {
+    const people = await fetchPeople();
+    renderRows(people);
+  } catch (error) {
+    errorMessage.textContent = error.message;
+    errorMessage.hidden = false;
+  }
+}
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  const payload = Object.fromEntries(formData.entries());
+
+  errorMessage.hidden = true;
+
+  try {
+    const response = await fetch("/api/people", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json();
+      throw new Error(errorBody.error ?? "Unable to save");
+    }
+
+    form.reset();
+    await refreshList();
+  } catch (error) {
+    errorMessage.textContent = error.message;
+    errorMessage.hidden = false;
+  }
+});
+
+refreshList();

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Simple Directory Demo</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <section class="intro">
+        <h1>Community Directory</h1>
+        <p>
+          This streamlined demo keeps only the essentials: first name, last name,
+          and ZIP code. Add new entries with the form below and they appear instantly
+          in the directory list.
+        </p>
+      </section>
+
+      <section class="form-card">
+        <h2>Add a person</h2>
+        <form id="person-form">
+          <label>
+            First name
+            <input type="text" name="first_name" required />
+          </label>
+          <label>
+            Last name
+            <input type="text" name="last_name" required />
+          </label>
+          <label>
+            ZIP code
+            <input type="text" name="zip_code" pattern="\\d{5}" required />
+          </label>
+          <button type="submit">Save</button>
+          <p class="error" role="alert" hidden></p>
+        </form>
+      </section>
+
+      <section class="table-card">
+        <h2>People</h2>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">First name</th>
+              <th scope="col">Last name</th>
+              <th scope="col">ZIP</th>
+            </tr>
+          </thead>
+          <tbody id="people-body"></tbody>
+        </table>
+      </section>
+    </main>
+
+    <script src="app.js" defer></script>
+  </body>
+</html>

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,127 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  background-color: #f6f7fb;
+  color: #1b1b1d;
+}
+
+body {
+  margin: 0;
+}
+
+.container {
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  max-width: 960px;
+  display: grid;
+  gap: 2rem;
+}
+
+.intro,
+.form-card,
+.table-card {
+  background-color: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.08);
+  padding: 2rem;
+}
+
+.intro h1 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+.intro p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.form-card form {
+  display: grid;
+  gap: 1rem;
+}
+
+label {
+  display: grid;
+  gap: 0.3rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+input[type="text"] {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease;
+}
+
+input[type="text"]:focus {
+  border-color: #2563eb;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+button[type="submit"] {
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+  justify-self: start;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+button[type="submit"]:hover {
+  background: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+button[type="submit"]:active {
+  transform: translateY(0);
+}
+
+.error {
+  margin: 0;
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.table-card table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #f1f5f9;
+  text-align: left;
+}
+
+th,
+td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e2e8f0;
+  font-size: 0.95rem;
+}
+
+tbody tr:hover {
+  background: rgba(37, 99, 235, 0.06);
+}
+
+td.empty {
+  text-align: center;
+  color: #64748b;
+}
+
+@media (min-width: 768px) {
+  .container {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .intro {
+    grid-column: 1 / -1;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the old WordPress-focused ignore list with a Python-friendly set
- build a lightweight SQLite-backed directory server using only the Python stdlib
- refresh the static UI to focus on first name, last name, and ZIP entries with simple styling

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e1716362e48329b61ef91921de5978