### PR TITLE
Revamp landing page styling with dark hero layout

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -7,19 +7,51 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <main class="container">
-      <section class="intro">
-        <h1>Community Directory</h1>
-        <p>
-          Capture a fuller picture of the people in your community. Record
-          demographics, education, work experience, and background details. New
-          entries appear instantly in the directory list below.
-        </p>
+    <header class="site-header">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <div class="brand-copy">
+          <p class="brand-tagline">Community Impact Team</p>
+          <p class="brand-name">Bridge Support Network</p>
+        </div>
+      </div>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="#about">About</a>
+        <a href="#volunteers">Volunteers</a>
+        <a href="#employment">Employment</a>
+        <a href="#donations">Donations</a>
+        <a href="#contact">Contact</a>
+      </nav>
+      <a class="cta-button" href="#donate">Donate</a>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-image" role="presentation"></div>
+        <div class="hero-overlay"></div>
+        <div class="hero-content">
+          <p class="hero-kicker">Helping bridge the gap</p>
+          <h1>Community Directory</h1>
+          <p>
+            Capture a fuller picture of the people in your community. Record
+            demographics, education, work experience, and background details. New
+            entries appear instantly in the directory list below.
+          </p>
+          <a class="hero-link" href="#people">Learn more</a>
+        </div>
+        <div class="vertical-label" aria-hidden="true">Bridge Support</div>
       </section>
 
-      <section class="form-card">
-        <h2>Add a person</h2>
-        <form id="person-form">
+      <div class="anchor-target" id="about" aria-hidden="true"></div>
+      <div class="anchor-target" id="volunteers" aria-hidden="true"></div>
+      <div class="anchor-target" id="employment" aria-hidden="true"></div>
+      <div class="anchor-target" id="donations" aria-hidden="true"></div>
+      <div class="anchor-target" id="contact" aria-hidden="true"></div>
+
+      <div class="content-grid">
+        <section class="card form-card" id="form">
+          <h2>Add a person</h2>
+          <form id="person-form">
           <div class="form-grid">
             <label>
               First name <span class="required-indicator" aria-hidden="true">*</span>
@@ -175,9 +207,9 @@
         </form>
       </section>
 
-      <section class="table-card">
-        <h2>People</h2>
-        <table>
+        <section class="card table-card" id="people">
+          <h2>People</h2>
+          <table>
           <thead>
             <tr>
               <th scope="col">ID</th>
@@ -200,7 +232,8 @@
           </thead>
           <tbody id="people-body"></tbody>
         </table>
-      </section>
+        </section>
+      </div>
     </main>
 
     <script src="app.js" defer></script>

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,42 +1,236 @@
 :root {
-  color-scheme: light;
-  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
-  background-color: #f6f7fb;
-  color: #1b1b1d;
+  color-scheme: dark;
+  font-family: "Poppins", "Segoe UI", system-ui, sans-serif;
+  background-color: #0f141b;
+  color: #f7f8fb;
+}
+
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap");
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
+  background: radial-gradient(circle at top right, rgba(255, 196, 45, 0.08), transparent 45%),
+    #0a0e14;
+  color: #e8ecf5;
 }
 
-.container {
-  margin: 0 auto;
-  padding: 3rem 1.5rem 4rem;
-  max-width: 960px;
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.25rem clamp(1rem, 5vw, 3rem);
+  background: rgba(8, 12, 18, 0.92);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  color: #f6f8fb;
+}
+
+.brand-mark {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #f2c94c, #f2994a);
+  box-shadow: 0 10px 30px rgba(242, 153, 74, 0.4);
+}
+
+.brand-copy {
   display: grid;
-  gap: 2rem;
+  gap: 0.15rem;
 }
 
-.intro,
-.form-card,
-.table-card {
-  background-color: #ffffff;
-  border-radius: 16px;
-  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.08);
-  padding: 2rem;
-}
-
-.intro h1 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
-  font-size: clamp(2rem, 4vw, 2.75rem);
-}
-
-.intro p {
+.brand-tagline {
   margin: 0;
-  line-height: 1.6;
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.68);
 }
 
+.brand-name {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 2.5rem);
+}
+
+.site-nav a {
+  font-weight: 500;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+  transition: color 0.2s ease;
+}
+
+.site-nav a:hover,
+.site-nav a:focus-visible {
+  color: #f2c94c;
+}
+
+.cta-button {
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #f2c94c, #f2994a);
+  color: #07080a;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: none;
+  box-shadow: 0 14px 35px rgba(242, 153, 74, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta-button:hover,
+.cta-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 40px rgba(242, 153, 74, 0.45);
+}
+
+main {
+  display: grid;
+  gap: clamp(2rem, 5vw, 3.5rem);
+}
+
+.hero {
+  position: relative;
+  min-height: clamp(320px, 70vh, 520px);
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.hero-image {
+  position: absolute;
+  inset: 0;
+  background: url("https://images.unsplash.com/photo-1515165562835-c4c5b2c07faa?auto=format&fit=crop&w=1600&q=80") center/cover;
+  filter: saturate(0.9) brightness(0.75);
+  transform: scale(1.1);
+}
+
+.hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(10, 15, 21, 0.92) 0%, rgba(10, 15, 21, 0.25) 60%);
+}
+
+.hero-content {
+  position: relative;
+  padding: clamp(2rem, 7vw, 5rem) clamp(1.5rem, 7vw, 6rem);
+  max-width: min(560px, 90vw);
+  display: grid;
+  gap: 1rem;
+}
+
+.hero-kicker {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(242, 201, 76, 0.85);
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.5rem, 6vw, 3.75rem);
+  font-weight: 700;
+}
+
+.hero p {
+  margin: 0;
+  line-height: 1.7;
+  color: rgba(232, 236, 245, 0.86);
+  font-weight: 300;
+}
+
+.hero-link {
+  justify-self: flex-start;
+  padding: 0.65rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.22em;
+  font-weight: 500;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.hero-link:hover,
+.hero-link:focus-visible {
+  background: rgba(255, 255, 255, 0.85);
+  color: #0a0e14;
+}
+
+.vertical-label {
+  position: absolute;
+  top: 50%;
+  left: clamp(0.5rem, 2vw, 1.5rem);
+  transform: translateY(-50%) rotate(-90deg);
+  transform-origin: left top;
+  font-size: 0.85rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.4);
+  font-weight: 500;
+  pointer-events: none;
+}
+
+.anchor-target {
+  position: relative;
+  top: -80px;
+  height: 0;
+}
+
+.content-grid {
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+  padding: 0 clamp(1rem, 7vw, 6rem) clamp(3rem, 8vw, 6rem);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.card {
+  background: linear-gradient(180deg, rgba(18, 25, 33, 0.95), rgba(9, 13, 18, 0.95));
+  border-radius: 20px;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 
 .form-card form {
   display: grid;
@@ -60,43 +254,54 @@ label {
 }
 
 label .required-indicator {
-  color: #dc2626;
+  color: #ff6b6b;
 }
 
 input[type="text"],
 input[type="date"] {
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 12px;
   padding: 0.65rem 0.75rem;
   font-size: 1rem;
-  transition: border-color 0.2s ease;
+  background: rgba(9, 13, 18, 0.75);
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type="text"]::placeholder,
+input[type="date"]::placeholder {
+  color: rgba(255, 255, 255, 0.45);
 }
 
 input[type="text"]:focus,
 input[type="date"]:focus {
-  border-color: #2563eb;
+  border-color: rgba(242, 201, 76, 0.75);
   outline: none;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  box-shadow: 0 0 0 4px rgba(242, 201, 76, 0.15);
 }
 
 .field-hint {
   margin: -0.75rem 0 0;
   font-size: 0.85rem;
-  color: #64748b;
+  color: rgba(255, 255, 255, 0.55);
 }
 
 .form-card form fieldset {
-  border: 1px solid #cbd5e1;
-  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
   padding: 1rem 1.25rem 1.25rem;
   display: grid;
   gap: 1rem;
+  background: rgba(10, 15, 21, 0.65);
 }
 
 .form-card form legend {
-  font-weight: 700;
-  font-size: 1rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
   padding: 0 0.25rem;
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .choice-grid {
@@ -113,6 +318,7 @@ input[type="date"]:focus {
 
 .choice-row span {
   font-weight: 600;
+  color: rgba(255, 255, 255, 0.82);
 }
 
 .choice-row label {
@@ -120,12 +326,13 @@ input[type="date"]:focus {
   align-items: center;
   gap: 0.35rem;
   font-weight: 500;
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .choice-row input[type="radio"] {
   width: 1rem;
   height: 1rem;
-  accent-color: #2563eb;
+  accent-color: #f2c94c;
 }
 
 .form-actions {
@@ -136,20 +343,25 @@ input[type="date"]:focus {
 }
 
 button[type="submit"] {
-  background: #2563eb;
-  color: white;
+  background: linear-gradient(135deg, #f2c94c, #f2994a);
+  color: #07080a;
   border: none;
   border-radius: 999px;
-  padding: 0.75rem 1.5rem;
-  font-size: 1rem;
+  padding: 0.75rem 1.75rem;
+  font-size: 0.95rem;
   cursor: pointer;
   justify-self: start;
-  transition: background 0.2s ease, transform 0.2s ease;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 14px 35px rgba(242, 153, 74, 0.35);
 }
 
-button[type="submit"]:hover {
-  background: #1d4ed8;
+button[type="submit"]:hover,
+button[type="submit"]:focus-visible {
   transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(242, 153, 74, 0.45);
 }
 
 button[type="submit"]:active {
@@ -158,7 +370,7 @@ button[type="submit"]:active {
 
 .error {
   margin: 0;
-  color: #b91c1c;
+  color: #ff6b6b;
   font-weight: 600;
 }
 
@@ -170,48 +382,50 @@ button[type="submit"]:active {
   width: 100%;
   border-collapse: collapse;
   min-width: 720px;
+  background: rgba(11, 16, 23, 0.65);
+  border-radius: 12px;
+  overflow: hidden;
 }
 
 thead {
-  background: #f1f5f9;
+  background: rgba(255, 255, 255, 0.04);
   text-align: left;
 }
 
 th,
 td {
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   font-size: 0.95rem;
+  color: rgba(235, 238, 245, 0.9);
 }
 
 tbody tr:hover {
-  background: rgba(37, 99, 235, 0.06);
+  background: rgba(242, 153, 74, 0.08);
 }
 
 td.empty {
   text-align: center;
-  color: #64748b;
+  color: rgba(255, 255, 255, 0.5);
 }
 
-@media (min-width: 768px) {
-  .container {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+@media (max-width: 960px) {
+  .site-header {
+    flex-wrap: wrap;
+    justify-content: center;
   }
 
-  .intro {
-    grid-column: 1 / -1;
+  .site-nav {
+    flex-wrap: wrap;
+    justify-content: center;
   }
 
-  .form-grid {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  .hero {
+    min-height: 420px;
   }
 
-  .form-card form fieldset {
-    padding: 1.25rem 1.5rem 1.5rem;
-  }
-
-  .choice-grid {
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  .vertical-label {
+    display: none;
   }
 }
 
@@ -223,5 +437,13 @@ td.empty {
 
   .choice-row label {
     justify-content: flex-start;
+  }
+
+  .site-header {
+    padding: 1rem 1.5rem;
+  }
+
+  .hero-content {
+    padding: 3rem 1.75rem;
   }
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -119,7 +119,7 @@ main {
 
 .hero {
   position: relative;
-  min-height: clamp(320px, 70vh, 520px);
+  min-height: clamp(320px, 55vh, 460px);
   display: flex;
   align-items: center;
   overflow: hidden;
@@ -142,8 +142,8 @@ main {
 
 .hero-content {
   position: relative;
-  padding: clamp(2rem, 7vw, 5rem) clamp(1.5rem, 7vw, 6rem);
-  max-width: min(560px, 90vw);
+  padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 7vw, 6rem);
+  max-width: min(700px, 70vw);
   display: grid;
   gap: 1rem;
 }


### PR DESCRIPTION
## Summary
- replace the simple layout with a branded header, hero banner, and call-to-action to echo the requested reference style
- refresh the global styling with a dark gradient theme, gold accent, and updated typography and components
- add anchor targets for navigation links to keep sticky header navigation functional

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e198d7b6988329838108fd7fe05bfd